### PR TITLE
.gitattributes: Set platform-specific line-endings for bash scripts and batch files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
+# Shell scripts (Unix-style line endings)
 *.sh    text eol=lf
+bin/apm text eol=lf
+bin/npm text eol=lf
+
+# Batch files (Windows-style line endings)
+*.cmd   text eol=crlf


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- Use the [`.gitattributes`](https://www.git-scm.com/docs/gitattributes#_eol) file to ensure:
  -  `.cmd` files are checked into/checked out of the git object store with Windows-friendly `CRLF` line endings.
  - bash scripts use Unix-friendly `LF` line endings.

See: https://en.wikipedia.org/wiki/Newline#Issues_with_different_newline_formats

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.

### Benefits

<!-- What benefits will be realized by the code change? -->

With this change, users should get working scripts as part of their `apm` install, regardless of what platform the module was published from.

(Wrong line endings can cause scripts not to run. It appears that without this PR, files may be checked out locally with wrong line endings, and subsequently published to the npm package registry with wrong line endings.)

(This PR expected to prevent platform-specific files from being published to the npm package registry with the wrong line endings.)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Changing the line endings of the bash scripts to `LF` allowed them to run on my Linux machine.

Presumably setting the `.cmd` files to have Windows line-endings has a similar benefit.

### Applicable Issues

<!-- Enter any applicable Issues here -->

#7 has a description of the problem this fixes. (This PR closes #7).