### PR TITLE
Use postinstall for running postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "node script/check-version.js && grunt",
     "prepare": "grunt prepare",
-    "install": "node script/postinstall.js",
+    "postinstall": "node script/postinstall.js",
     "test": "node script/check-version.js && grunt test",
     "check-version": "node version.js"
   },


### PR DESCRIPTION
### Description of change
Use postinstall for running postinstall script instead of using install.

Based on the docs:
> install, postinstall: Run AFTER the package is installed
https://docs.npmjs.com/misc/scripts#description

### Verification
This is a trivial change. The CI passes

### Release Notes
- Use postinstall for running postinstall script instead of using install.


