### PR TITLE
Optimize getResourcePath

### DIFF
--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -25,6 +25,9 @@ module.exports =
     if process.env.ATOM_RESOURCE_PATH
       return process.nextTick -> callback(process.env.ATOM_RESOURCE_PATH)
 
+    if asarPath # already calculated
+      return process.nextTick -> callback(asarPath)
+
     apmFolder = path.resolve(__dirname, '..')
     appFolder = path.dirname(apmFolder)
     if path.basename(apmFolder) is 'apm' and path.basename(appFolder) is 'app'
@@ -51,11 +54,10 @@ module.exports =
           appLocation = '/usr/share/atom/resources/app.asar'
         process.nextTick -> callback(appLocation)
       when 'win32'
-        if (asarPath is null)
-          glob = require 'glob'
-          pattern = "/Users/#{process.env.USERNAME}/AppData/Local/atom/app-+([0-9]).+([0-9]).+([0-9])/resources/app.asar"
-          asarPaths = glob.sync(pattern, null) # [] | a sorted array of locations with the newest version being last
-          asarPath = asarPaths[asarPaths.length - 1]
+        glob = require 'glob'
+        pattern = "/Users/#{process.env.USERNAME}/AppData/Local/atom/app-+([0-9]).+([0-9]).+([0-9])/resources/app.asar"
+        asarPaths = glob.sync(pattern, null) # [] | a sorted array of locations with the newest version being last
+        asarPath = asarPaths[asarPaths.length - 1]
         return process.nextTick -> callback(asarPath)
       else
         return process.nextTick -> callback('')

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -47,7 +47,8 @@ module.exports =
         child_process.exec 'mdfind "kMDItemCFBundleIdentifier == \'com.github.atom\'"', (error, stdout='', stderr) ->
           [appLocation] = stdout.split('\n') unless error
           appLocation = '/Applications/Atom.app' unless appLocation
-          callback("#{appLocation}/Contents/Resources/app.asar")
+          asarPath = "#{appLocation}/Contents/Resources/app.asar"
+          return process.nextTick -> callback(asarPath)
       when 'linux'
         appLocation = '/usr/local/share/atom/resources/app.asar'
         unless fs.existsSync(appLocation)

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -50,10 +50,10 @@ module.exports =
           asarPath = "#{appLocation}/Contents/Resources/app.asar"
           return process.nextTick -> callback(asarPath)
       when 'linux'
-        appLocation = '/usr/local/share/atom/resources/app.asar'
+        asarPath = '/usr/local/share/atom/resources/app.asar'
         unless fs.existsSync(appLocation)
-          appLocation = '/usr/share/atom/resources/app.asar'
-        process.nextTick -> callback(appLocation)
+          asarPath = '/usr/share/atom/resources/app.asar'
+        return process.nextTick -> callback(asarPath)
       when 'win32'
         glob = require 'glob'
         pattern = "/Users/#{process.env.USERNAME}/AppData/Local/atom/app-+([0-9]).+([0-9]).+([0-9])/resources/app.asar"


### PR DESCRIPTION
### Description of the change

As a continuation of #27 this optimizes getResourcePath by storing a cache of the asarPath. This means asarPath is only calculated once.

### Verification
The tests continue to pass.

### Benefits
Caching the code means the scripts run faster after the first apm script is called.

### Release Notes
- faster getResourcePath by caching the asarPath