### PR TITLE
Use ES6 syntax in scripts + parallel node-gyp

### DIFF
--- a/script/bundled-node-version.js
+++ b/script/bundled-node-version.js
@@ -1,4 +1,4 @@
-var child_process = require('child_process')
+const child_process = require('child_process')
 
 module.exports = function(filename, callback) {
   child_process.exec(filename + ' -v', function(error, stdout) {
@@ -7,13 +7,13 @@ module.exports = function(filename, callback) {
       return;
     }
 
-    var version = null;
+    let version = null;
     if (stdout != null) {
       version = stdout.toString().trim();
     }
 
     child_process.exec(filename + " -p 'process.arch'", function(error, stdout) {
-      var arch = null;
+      let arch = null;
       if (stdout != null) {
         arch = stdout.toString().trim();
       }

--- a/script/check-version.js
+++ b/script/check-version.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-var path = require('path');
+const path = require('path');
 
-var getBundledNodeVersion = require('./bundled-node-version')
+const getBundledNodeVersion = require('./bundled-node-version')
 
-var bundledNodePath = path.join(__dirname, '..', 'bin', 'node')
+let bundledNodePath = path.join(__dirname, '..', 'bin', 'node')
 if (process.platform === 'win32') {
   bundledNodePath += '.exe'
 }
@@ -15,10 +15,10 @@ getBundledNodeVersion(bundledNodePath, function(err, bundledVersion) {
     process.exit(1);
   }
 
-  var ourVersion = process.version
+  const ourVersion = process.version
 
   if (ourVersion !== bundledVersion) {
-    console.error('System node (' + ourVersion + ') does not match bundled node (' + bundledVersion + ').');
+    console.error(`System node (${ourVersion}) does not match bundled node (${bundledVersion}).`);
     if (process.platform === 'win32') {
       console.error('Please use `.\\bin\\node.exe` to run node, and use `.\\bin\\npm.cmd` to run npm scripts.')
     } else {

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -1,29 +1,29 @@
-var fs = require('fs');
-var mv = require('mv');
-var zlib = require('zlib');
-var path = require('path');
+const fs = require('fs');
+const mv = require('mv');
+const zlib = require('zlib');
+const path = require('path');
 
-var tar = require('tar');
-var temp = require('temp');
+const tar = require('tar');
+const temp = require('temp');
 
-var request = require('request');
-var getInstallNodeVersion = require('./bundled-node-version')
+const request = require('request');
+const getInstallNodeVersion = require('./bundled-node-version')
 
 temp.track();
 
-var identifyArch = function() {
+const identifyArch = function() {
   switch (process.arch) {
     case "ia32":  return "x86";
-    case "arm":   return "armv" + process.config.variables.arm_version + "l";
+    case "arm":   return `armv${process.config.variables.arm_version}l`;
     default:      return process.arch;
   }
 };
 
-var downloadFileToLocation = function(url, filename, callback) {
-  var stream = fs.createWriteStream(filename);
+const downloadFileToLocation = function(url, filename, callback) {
+  const stream = fs.createWriteStream(filename);
   stream.on('end', callback);
   stream.on('error', callback);
-  var requestStream = request.get(url)
+  const requestStream = request.get(url)
   requestStream.on('response', function(response) {
     if (response.statusCode == 404) {
       console.error('download not found:', url);
@@ -33,16 +33,16 @@ var downloadFileToLocation = function(url, filename, callback) {
   });
 };
 
-var downloadTarballAndExtract = function(url, location, callback) {
-  var tempPath = temp.mkdirSync('apm-node-');
-  var stream = tar.extract({
+const downloadTarballAndExtract = function(url, location, callback) {
+  const tempPath = temp.mkdirSync('apm-node-');
+  const stream = tar.extract({
     cwd: tempPath
   });
   stream.on('end', function() {
     callback.call(this, tempPath);
   });
   stream.on('error', callback);
-  var requestStream = request.get(url)
+  const requestStream = request.get(url)
   requestStream.on('response', function(response) {
     if (response.statusCode == 404) {
       console.error('download not found:', url);
@@ -52,10 +52,10 @@ var downloadTarballAndExtract = function(url, location, callback) {
   });
 };
 
-var copyNodeBinToLocation = function(callback, version, targetFilename, fromDirectory) {
-  var arch = identifyArch();
-  var subDir = "node-" + version + "-" + process.platform + "-" + arch;
-  var downloadedNodePath = path.join(fromDirectory, subDir, 'bin', 'node');
+const copyNodeBinToLocation = function(callback, version, targetFilename, fromDirectory) {
+  const arch = identifyArch();
+  const subDir = `node-${version}-${process.platform}-${arch}`;
+  const downloadedNodePath = path.join(fromDirectory, subDir, 'bin', 'node');
   return mv(downloadedNodePath, targetFilename, {mkdirp: true}, function(err) {
     if (err) {
       callback(err);
@@ -67,16 +67,16 @@ var copyNodeBinToLocation = function(callback, version, targetFilename, fromDire
   });
 };
 
-var downloadNode = function(version, done) {
-  var arch = identifyArch();
-  var filename = path.join(__dirname, '..', 'bin', process.platform === 'win32' ? 'node.exe' : 'node');
+const downloadNode = function(version, done) {
+  const arch = identifyArch();
+  const filename = path.join(__dirname, '..', 'bin', process.platform === 'win32' ? 'node.exe' : 'node');
 
-  var downloadFile = function() {
+  const downloadFile = function() {
     if (process.platform === 'win32') {
-      downloadFileToLocation("https://nodejs.org/dist/" + version + "/win-" + arch + "/node.exe", filename, done);
+      downloadFileToLocation(`https://nodejs.org/dist/${version}/win-${arch}/node.exe`, filename, done);
     } else {
-      var next = copyNodeBinToLocation.bind(this, done, version, filename);
-      downloadTarballAndExtract("https://nodejs.org/dist/" + version + "/node-" + version + "-" + process.platform + "-" + arch + ".tar.gz", filename, next);
+      const next = copyNodeBinToLocation.bind(this, done, version, filename);
+      downloadTarballAndExtract(`https://nodejs.org/dist/${version}/node-${version}-${process.platform}-${arch}.tar.gz`, filename, next);
     }
   }
 
@@ -95,7 +95,7 @@ var downloadNode = function(version, done) {
   }
 };
 
-var versionToInstall = fs.readFileSync(path.resolve(__dirname, '..', 'BUNDLED_NODE_VERSION'), 'utf8').trim()
+const versionToInstall = fs.readFileSync(path.resolve(__dirname, '..', 'BUNDLED_NODE_VERSION'), 'utf8').trim()
 downloadNode(versionToInstall, function(error) {
   if (error != null) {
     console.error('Failed to download node', error);

--- a/script/postinstall.cmd
+++ b/script/postinstall.cmd
@@ -8,6 +8,10 @@ node .\script\download-node.js
 echo.
 for /f "delims=" %%i in ('.\bin\node.exe -p "process.version + ' ' + process.arch"') do set bundledVersion=%%i
 echo ^>^> Rebuilding apm dependencies with bundled Node !bundledVersion!
+
+# parallel node-gyp
+set JOBS=16
+
 call .\bin\npm.cmd rebuild
 
 echo.

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-var cp = require('child_process')
-var fs = require('fs')
-var path = require('path')
+const cp = require('child_process')
+const fs = require('fs')
+const path = require('path')
 
-var script = path.join(__dirname, 'postinstall')
+let script = path.join(__dirname, 'postinstall')
 if (process.platform === 'win32') {
   script += '.cmd'
 } else {
@@ -18,6 +18,6 @@ fs.chmodSync(script, 0o755)
 fs.chmodSync(path.join(__dirname, '..', 'bin', 'apm'), 0o755)
 fs.chmodSync(path.join(__dirname, '..', 'bin', 'npm'), 0o755)
 
-var child = cp.spawn(script, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })
+const child = cp.spawn(script, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })
 child.stderr.pipe(process.stderr)
 child.stdout.pipe(process.stdout)

--- a/script/postinstall.sh
+++ b/script/postinstall.sh
@@ -7,6 +7,10 @@ node script/download-node.js
 
 echo
 echo ">> Rebuilding apm dependencies with bundled Node $(./bin/node -p "process.version + ' ' + process.arch")"
+
+# parallel node-gyp
+JOBS=16
+
 ./bin/npm rebuild
 
 echo


### PR DESCRIPTION
### Description of change

- This uses ES6 syntax in the scripts
	- using let/const instead of var
	- using string templates instead of concatenating strings using +

- Set JOBS env variable to build the native files in parallel

### Verification
- The CI passes, and the tests run locally.
- The scripts change is automated using [resugar](https://github.com/resugar/resugar) so no human mistake is possible.

### Release Notes
- ES6 syntax in build scripts
- Using parallel node-gyp


